### PR TITLE
avoid changing original values when validating

### DIFF
--- a/lib/validates_cpf_cnpj/cnpj.rb
+++ b/lib/validates_cpf_cnpj/cnpj.rb
@@ -1,7 +1,7 @@
 module ValidatesCpfCnpj
   module Cnpj
-    def self.valid?(value)
-      value.gsub!(/[^0-9]/, '')
+    def self.valid?(original_value)
+      value = original_value.gsub(/[^0-9]/, '')
       digit = value.slice(-2, 2)
       control = ''
       if value.size == 14

--- a/lib/validates_cpf_cnpj/cpf.rb
+++ b/lib/validates_cpf_cnpj/cpf.rb
@@ -2,8 +2,8 @@ module ValidatesCpfCnpj
   module Cpf
     @@invalid_cpfs = %w{12345678909 11111111111 22222222222 33333333333 44444444444 55555555555 66666666666 77777777777 88888888888 99999999999 00000000000}
 
-    def self.valid?(value)
-      value.gsub!(/[^0-9]/, '')
+    def self.valid?(original_value)
+      value = original_value.gsub(/[^0-9]/, '')
 
       return false if @@invalid_cpfs.member?(value)
       


### PR DESCRIPTION
O `gsub!` (com bang) estava alterando o valor original (removendo a formatação). Acho que nem sempre é desejado remover a formatação; pelo menos não fica claro que o validador vai alterar o valor original do campo.
