### PR TITLE
Improvements and Corrections: separated validations for CPF and CNPJ, added dependencies, updated tests to Rspec3, make validation keep original value, value normalization after validation & some bug fixes.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in validates_cpf_cnpj.gemspec
 gemspec
+
+gem 'sqlite3'

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source "http://rubygems.org"
 
 # Specify your gem's dependencies in validates_cpf_cnpj.gemspec
 gemspec
-
-gem 'sqlite3'

--- a/README.rdoc
+++ b/README.rdoc
@@ -50,6 +50,7 @@ Regular validation options:
   :if          - Executes validation when :if evaluates true
   :unless      - Executes validation when :unless evaluates false
   :on          - Specifies validation context (e.g :save, :create or :update). Default is :save
+  :message     - Sets a custom message to be passed to the attribute (default is 'is invalid')
 
 == Contributing
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -52,6 +52,13 @@ Regular validation options:
   :on          - Specifies validation context (e.g :save, :create or :update). Default is :save
   :message     - Sets a custom message to be passed to the attribute (default is 'is invalid')
 
+CPF and CNPJ formatting:
+
+  When you run the validation on an attribute, if the value is a valid CPF or CNPJ, it will be formatted as so:
+  - valid CPF will be returned as 999.999.999-99
+  - valid CNPJ will be returned as 99.999.999/9999-99
+
+
 == Contributing
 
 Feel free to fork, fix and send me a pull request.

--- a/lib/validates_cpf_cnpj.rb
+++ b/lib/validates_cpf_cnpj.rb
@@ -8,6 +8,7 @@ module ActiveModel
       include ValidatesCpfCnpj
 
       def validate_each(record, attr_name, value)
+        puts "#{}"
         return if should_skip?(record, attr_name, value)
         if value.to_s.gsub(/[^0-9]/, '').length <= 11
           validate_only_cpf(record, attr_name, value)
@@ -33,6 +34,7 @@ module ActiveModel
         if (not value.to_s.match(/\A\d{11}\z/) and not value.to_s.match(/\A\d{3}\.\d{3}\.\d{3}\-\d{2}\z/)) or not Cpf.valid?(value)
           record.errors.add(attr_name)
         end
+        normalize_cpf(record, attr_name, value)
       end
 
       def validate_only_cnpj(record, attr_name, value)
@@ -40,6 +42,7 @@ module ActiveModel
         if (not value.to_s.match(/\A\d{14}\z/) and not value.to_s.match(/\A\d{2}\.\d{3}\.\d{3}\/\d{4}\-\d{2}\z/)) or not Cnpj.valid?(value)
           record.errors.add(attr_name)
         end
+        normalize_cnpj(record, attr_name, value)
       end
 
       def normalize_cpf(record, attr_name, value)

--- a/lib/validates_cpf_cnpj.rb
+++ b/lib/validates_cpf_cnpj.rb
@@ -8,26 +8,49 @@ module ActiveModel
       include ValidatesCpfCnpj
 
       def validate_each(record, attr_name, value)
-        return if (options[:allow_nil] and value.nil?) or (options[:allow_blank] and value.blank?)
-        return if (options[:if] == false) or (options[:unless] == true)
-        return if (options[:on].to_s == 'create' and not record.new_record?) or (options[:on].to_s == 'update' and record.new_record?)
-
+        return if should_skip?(record, attr_name, value)
         if value.to_s.gsub(/[^0-9]/, '').length <= 11
-          if (not value.to_s.match(/\A\d{11}\z/) and not value.to_s.match(/\A\d{3}\.\d{3}\.\d{3}\-\d{2}\z/)) or not Cpf.valid?(value)
-            record.errors.add(attr_name)
-          end
+          validate_only_cpf(record, attr_name, value)
         else
-          if (not value.to_s.match(/\A\d{14}\z/) and not value.to_s.match(/\A\d{2}\.\d{3}\.\d{3}\/\d{4}\-\d{2}\z/)) or not Cnpj.valid?(value)
-            record.errors.add(attr_name)
-          end
+          validate_only_cnpj(record, attr_name, value)
+        end
+      end
+
+      protected
+
+      def should_skip?(record, attr_name, value)
+        if ((options[:allow_nil] and value.nil?) or (options[:allow_blank] and value.blank?)) or  
+           ((options[:if] == false) or (options[:unless] == true)) or  
+           ((options[:on].to_s == 'create' and not record.new_record?) or (options[:on].to_s == 'update' and record.new_record?))
+          true
+        end
+      end
+
+      def validate_only_cpf(record, attr_name, value)
+        return if should_skip?(record, attr_name, value)
+        if (not value.to_s.match(/\A\d{11}\z/) and not value.to_s.match(/\A\d{3}\.\d{3}\.\d{3}\-\d{2}\z/)) or not Cpf.valid?(value)
+          record.errors.add(attr_name)
+        end
+      end
+
+      def validate_only_cnpj(record, attr_name, value)
+        return if should_skip?(record, attr_name, value)
+        if (not value.to_s.match(/\A\d{14}\z/) and not value.to_s.match(/\A\d{2}\.\d{3}\.\d{3}\/\d{4}\-\d{2}\z/)) or not Cnpj.valid?(value)
+          record.errors.add(attr_name)
         end
       end
     end
 
     class CpfValidator < CpfOrCnpjValidator
+      def validate_each(record, attr_name, value)
+        validate_only_cpf(record, attr_name, value)
+      end
     end
 
     class CnpjValidator < CpfOrCnpjValidator
+      def validate_each(record, attr_name, value)
+        validate_only_cnpj(record, attr_name, value)
+      end
     end
 
     module HelperMethods

--- a/lib/validates_cpf_cnpj.rb
+++ b/lib/validates_cpf_cnpj.rb
@@ -6,7 +6,7 @@ module ActiveModel
   module Validations
     class CpfOrCnpjValidator < ActiveModel::EachValidator
       include ValidatesCpfCnpj
-      
+
       ELEVEN_DIGITS_REGEXP = /\A\d{11}\z/
       FOURTEEN_DIGITS_REGEXP = /\A\d{14}\z/
       CPF_FORMAT_REGEXP = /\A\d{3}\.\d{3}\.\d{3}\-\d{2}\z/
@@ -14,19 +14,19 @@ module ActiveModel
       NOT_DIGITS_REGEXP = /[^0-9]/
 
       def validate_each(record, attr_name, value)
-        return if (options[:allow_nil] and value.nil?) or (options[:allow_blank] and value.blank?)
-        return if (options[:if] == false) or (options[:unless] == true)
-        return if (options[:on].to_s == 'create' and not record.new_record?) or (options[:on].to_s == 'update' and record.new_record?)
-        
+        return if (options[:allow_nil] && value.nil?) || (options[:allow_blank] && value.blank?)
+        return if (options[:if] == false) || (options[:unless] == true)
+        return if (options[:on].to_s == 'create' && !record.new_record?) || (options[:on].to_s == 'update' && record.new_record?)
+
         inside_cpf_length = value.to_s.gsub(NOT_DIGITS_REGEXP, '').length <= 11
-        invalid_cpf_format = not value.to_s.match(ELEVEN_DIGITS_REGEXP) and not value.to_s.match(CPF_FORMAT_REGEXP))
-        invalid_cnpj_format = not value.to_s.match(FOURTEEN_DIGITS_REGEXP) and not value.to_s.match(CNPJ_FORMAT_REGEXP))
-        
-        value_is_invalid = inside_cpf_length && (invalid_cpf_format or not Cpf.valid?(value))
-        value_is_invalid |= !inside_cpf_length && (invalid_cnpj_format or not Cnpj.valid?(value))
-        
+        valid_cpf_format = value.to_s.match(ELEVEN_DIGITS_REGEXP) || value.to_s.match(CPF_FORMAT_REGEXP)
+        valid_cnpj_format = value.to_s.match(FOURTEEN_DIGITS_REGEXP) || value.to_s.match(CNPJ_FORMAT_REGEXP)
+
+        value_is_invalid = inside_cpf_length && !(valid_cpf_format && Cpf.valid?(value))
+        value_is_invalid |= !inside_cpf_length && !(valid_cnpj_format && Cnpj.valid?(value))
+
         return unless value_is_invalid
-        
+
         if options[:message]
           record.errors.add(attr_name, options[:message])
         else

--- a/lib/validates_cpf_cnpj.rb
+++ b/lib/validates_cpf_cnpj.rb
@@ -11,16 +11,18 @@ module ActiveModel
         return if should_skip?(record, attr_name, value)
         if value.to_s.gsub(/[^0-9]/, '').length <= 11
           validate_only_cpf(record, attr_name, value)
+          normalize_cpf(record, attr_name, value)
         else
           validate_only_cnpj(record, attr_name, value)
+          normalize_cnpj(record, attr_name, value)
         end
       end
 
       protected
 
       def should_skip?(record, attr_name, value)
-        if ((options[:allow_nil] and value.nil?) or (options[:allow_blank] and value.blank?)) or  
-           ((options[:if] == false) or (options[:unless] == true)) or  
+        if ((options[:allow_nil] and value.nil?) or (options[:allow_blank] and value.blank?)) or
+           ((options[:if] == false) or (options[:unless] == true)) or
            ((options[:on].to_s == 'create' and not record.new_record?) or (options[:on].to_s == 'update' and record.new_record?))
           true
         end
@@ -37,6 +39,20 @@ module ActiveModel
         return if should_skip?(record, attr_name, value)
         if (not value.to_s.match(/\A\d{14}\z/) and not value.to_s.match(/\A\d{2}\.\d{3}\.\d{3}\/\d{4}\-\d{2}\z/)) or not Cnpj.valid?(value)
           record.errors.add(attr_name)
+        end
+      end
+
+      def normalize_cpf(record, attr_name, value)
+        if value
+          formatted = "#{value[0..2]}.#{value[3..5]}.#{value[6..8]}-#{value[9..10]}"
+          record.send("#{attr_name}=", formatted)
+        end
+      end
+
+      def normalize_cnpj(record, attr_name, value)
+        if value
+          formatted = "#{value[0..1]}.#{value[2..4]}.#{value[5..7]}/#{value[8..11]}-#{value[12..13]}"
+          record.send("#{attr_name}=", formatted)
         end
       end
     end

--- a/lib/validates_cpf_cnpj.rb
+++ b/lib/validates_cpf_cnpj.rb
@@ -8,7 +8,6 @@ module ActiveModel
       include ValidatesCpfCnpj
 
       def validate_each(record, attr_name, value)
-        puts "#{}"
         return if should_skip?(record, attr_name, value)
         if value.to_s.gsub(/[^0-9]/, '').length <= 11
           validate_only_cpf(record, attr_name, value)

--- a/lib/validates_cpf_cnpj/cnpj.rb
+++ b/lib/validates_cpf_cnpj/cnpj.rb
@@ -1,15 +1,15 @@
 module ValidatesCpfCnpj
   module Cnpj
     def self.valid?(value)
-      value.gsub!(/[^0-9]/, '')
-      digit = value.slice(-2, 2)
+      local_value = value.gsub(/[^0-9]/, '')
+      digit = local_value.slice(-2, 2)
       control = ''
-      if value.size == 14
+      if local_value.size == 14
         factor = 0
         2.times do |i|
           sum = 0;
           12.times do |j|
-            sum += value.slice(j, 1).to_i * ((11 + i - j) % 8 + 2)
+            sum += local_value.slice(j, 1).to_i * ((11 + i - j) % 8 + 2)
           end
           sum += factor * 2 if i == 1
           factor = 11 - sum  % 11

--- a/lib/validates_cpf_cnpj/cnpj.rb
+++ b/lib/validates_cpf_cnpj/cnpj.rb
@@ -1,7 +1,7 @@
 module ValidatesCpfCnpj
   module Cnpj
-    def self.valid?(value)
-      value.gsub!(/[^0-9]/, '')
+    def self.valid?(original_value)
+      value = original_value.gsub(/[^0-9]/, '')
       digit = value.slice(-2, 2)
       control = ''
       if value.size == 14

--- a/lib/validates_cpf_cnpj/cnpj.rb
+++ b/lib/validates_cpf_cnpj/cnpj.rb
@@ -3,7 +3,7 @@ module ValidatesCpfCnpj
     def self.valid?(value)
       value.gsub!(/[^0-9]/, '')
       
-      fourteen_plus_equal_characters_regexp = \A(\d)\1{13,}\z
+      fourteen_plus_equal_characters_regexp = /\A(\d)\1{13,}\z/
       return false if value =~ fourteen_plus_equal_characters_regexp
       
       digit = value.slice(-2, 2)

--- a/lib/validates_cpf_cnpj/cnpj.rb
+++ b/lib/validates_cpf_cnpj/cnpj.rb
@@ -1,12 +1,14 @@
 module ValidatesCpfCnpj
   module Cnpj
+    NON_DIGITS_REGEXP = /[^0-9]/
+    FOURTEEN_PLUS_EQUAL_CHARACTERS_REGEXP = /\A(\d)\1{13,}\z/
+
     def self.valid?(value)
-      value_only_digits = value.gsub(/[^0-9]/, '')
+      value_only_digits = value.gsub(NON_DIGITS_REGEXP, '')
 
-      fourteen_plus_equal_characters_regexp = /\A(\d)\1{13,}\z/
-      return false if value_only_digits =~ fourteen_plus_equal_characters_regexp
+      return false if value_only_digits =~ FOURTEEN_PLUS_EQUAL_CHARACTERS_REGEXP
 
-      digit = value.slice(-2, 2)
+      digit = value_only_digits.slice(-2, 2)
       control = ''
       if value_only_digits.size == 14
         factor = 0

--- a/lib/validates_cpf_cnpj/cnpj.rb
+++ b/lib/validates_cpf_cnpj/cnpj.rb
@@ -1,19 +1,19 @@
 module ValidatesCpfCnpj
   module Cnpj
     def self.valid?(value)
-      value.gsub!(/[^0-9]/, '')
-      
+      value_only_digits = value.gsub(/[^0-9]/, '')
+
       fourteen_plus_equal_characters_regexp = /\A(\d)\1{13,}\z/
-      return false if value =~ fourteen_plus_equal_characters_regexp
-      
+      return false if value_only_digits =~ fourteen_plus_equal_characters_regexp
+
       digit = value.slice(-2, 2)
       control = ''
-      if value.size == 14
+      if value_only_digits.size == 14
         factor = 0
         2.times do |i|
           sum = 0;
           12.times do |j|
-            sum += value.slice(j, 1).to_i * ((11 + i - j) % 8 + 2)
+            sum += value_only_digits.slice(j, 1).to_i * ((11 + i - j) % 8 + 2)
           end
           sum += factor * 2 if i == 1
           factor = 11 - sum  % 11

--- a/lib/validates_cpf_cnpj/cnpj.rb
+++ b/lib/validates_cpf_cnpj/cnpj.rb
@@ -2,6 +2,10 @@ module ValidatesCpfCnpj
   module Cnpj
     def self.valid?(value)
       value.gsub!(/[^0-9]/, '')
+      
+      fourteen_plus_equal_characters_regexp = \A(\d)\1{13,}\z
+      return false if value =~ fourteen_plus_equal_characters_regexp
+      
       digit = value.slice(-2, 2)
       control = ''
       if value.size == 14

--- a/lib/validates_cpf_cnpj/cpf.rb
+++ b/lib/validates_cpf_cnpj/cpf.rb
@@ -3,18 +3,18 @@ module ValidatesCpfCnpj
     @@invalid_cpfs = %w{12345678909 11111111111 22222222222 33333333333 44444444444 55555555555 66666666666 77777777777 88888888888 99999999999 00000000000}
 
     def self.valid?(value)
-      value.gsub!(/[^0-9]/, '')
+      value_only_digits = value.gsub(/[^0-9]/, '')
 
-      return false if @@invalid_cpfs.member?(value)
-      
-      digit = value.slice(-2, 2)
+      return false if @@invalid_cpfs.member?(value_only_digits)
+
+      digit = value_only_digits.slice(-2, 2)
       control = ''
-      if value.size == 11
+      if value_only_digits.size == 11
         factor = 0
         2.times do |i|
           sum = 0
           9.times do |j|
-            sum += value.slice(j, 1).to_i * (10 + i - j)
+            sum += value_only_digits.slice(j, 1).to_i * (10 + i - j)
           end
           sum += (factor * 2) if i == 1
           factor = (sum * 10) % 11

--- a/lib/validates_cpf_cnpj/cpf.rb
+++ b/lib/validates_cpf_cnpj/cpf.rb
@@ -1,9 +1,10 @@
 module ValidatesCpfCnpj
   module Cpf
     @@invalid_cpfs = %w{12345678909 11111111111 22222222222 33333333333 44444444444 55555555555 66666666666 77777777777 88888888888 99999999999 00000000000}
+    NON_DIGITS_REGEXP = /[^0-9]/
 
     def self.valid?(value)
-      value_only_digits = value.gsub(/[^0-9]/, '')
+      value_only_digits = value.gsub(NON_DIGITS_REGEXP, '')
 
       return false if @@invalid_cpfs.member?(value_only_digits)
 

--- a/lib/validates_cpf_cnpj/cpf.rb
+++ b/lib/validates_cpf_cnpj/cpf.rb
@@ -3,18 +3,18 @@ module ValidatesCpfCnpj
     @@invalid_cpfs = %w{12345678909 11111111111 22222222222 33333333333 44444444444 55555555555 66666666666 77777777777 88888888888 99999999999 00000000000}
 
     def self.valid?(value)
-      value.gsub!(/[^0-9]/, '')
+      local_value = value.gsub(/[^0-9]/, '')
 
-      return false if @@invalid_cpfs.member?(value)
-      
-      digit = value.slice(-2, 2)
+      return false if @@invalid_cpfs.member?(local_value)
+
+      digit = local_value.slice(-2, 2)
       control = ''
-      if value.size == 11
+      if local_value.size == 11
         factor = 0
         2.times do |i|
           sum = 0
           9.times do |j|
-            sum += value.slice(j, 1).to_i * (10 + i - j)
+            sum += local_value.slice(j, 1).to_i * (10 + i - j)
           end
           sum += (factor * 2) if i == 1
           factor = (sum * 10) % 11

--- a/lib/validates_cpf_cnpj/cpf.rb
+++ b/lib/validates_cpf_cnpj/cpf.rb
@@ -2,8 +2,8 @@ module ValidatesCpfCnpj
   module Cpf
     @@invalid_cpfs = %w{12345678909 11111111111 22222222222 33333333333 44444444444 55555555555 66666666666 77777777777 88888888888 99999999999 00000000000}
 
-    def self.valid?(value)
-      value.gsub!(/[^0-9]/, '')
+    def self.valid?(original_value)
+      value = original_value.gsub(/[^0-9]/, '')
 
       return false if @@invalid_cpfs.member?(value)
       

--- a/lib/validates_cpf_cnpj/version.rb
+++ b/lib/validates_cpf_cnpj/version.rb
@@ -1,3 +1,3 @@
 module ValidatesCpfCnpj
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/lib/validates_cpf_cnpj/version.rb
+++ b/lib/validates_cpf_cnpj/version.rb
@@ -1,3 +1,3 @@
 module ValidatesCpfCnpj
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end

--- a/lib/validates_cpf_cnpj/version.rb
+++ b/lib/validates_cpf_cnpj/version.rb
@@ -1,3 +1,3 @@
 module ValidatesCpfCnpj
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/lib/validates_cpf_cnpj/version.rb
+++ b/lib/validates_cpf_cnpj/version.rb
@@ -1,3 +1,3 @@
 module ValidatesCpfCnpj
-  VERSION = "0.2.1"
+  VERSION = "1.0.0"
 end

--- a/spec/lib/validates_cpf_cnpj_spec.rb
+++ b/spec/lib/validates_cpf_cnpj_spec.rb
@@ -85,7 +85,7 @@ describe ValidatesCpfCnpj do
 
       it ':on option is :create and the model instance is not a new record' do
         person = Person.new(:code => '12345678901')
-        person.stub!(:new_record?, false)
+        person.stub(:new_record?).and_return(false)
         person.validates_cpf(:code, :on => :create)
         person.errors.should be_empty
       end
@@ -173,7 +173,7 @@ describe ValidatesCpfCnpj do
 
       it ':on option is :create and the model instance is not a new record' do
         person = Person.new(:code => '12345678901')
-        person.stub!(:new_record?, false)
+        person.stub(:new_record?).and_return(false)
         person.validates_cnpj(:code, :on => :create)
         person.errors.should be_empty
       end
@@ -259,7 +259,7 @@ describe ValidatesCpfCnpj do
 
       it ':on option is :create and the model instance is not a new record' do
         person = Person.new(:code => '12345678901')
-        person.stub!(:new_record?, false)
+        person.stub(:new_record?).and_return(false)
         person.validates_cpf_or_cnpj(:code, :on => :create)
         person.errors.should be_empty
       end
@@ -312,7 +312,7 @@ describe ValidatesCpfCnpj do
 
       it ':on option is :create and the model instance is not a new record' do
         person = Person.new(:code => '12345678901')
-        person.stub!(:new_record?, false)
+        person.stub(:new_record?).and_return(false)
         person.validates_cpf_or_cnpj(:code, :on => :create)
         person.errors.should be_empty
       end

--- a/spec/lib/validates_cpf_cnpj_spec.rb
+++ b/spec/lib/validates_cpf_cnpj_spec.rb
@@ -106,7 +106,7 @@ describe ValidatesCpfCnpj do
 
     context 'should be invalid when' do
 
-      invalid_cnpjs = %w{1234567890123 12345678901234 123456789012345 ABC05393625000184 12.345.678/9012-34 05393.625/0001-84 05393.6250001-84}
+      invalid_cnpjs = %w{1234567890123 12345678901234 123456789012345 ABC05393625000184 12.345.678/9012-34 05393.625/0001-84 05393.6250001-84 00.000.000/0000-00}
 
       invalid_cnpjs.each do |cnpj|
         it "value is #{cnpj}" do
@@ -116,7 +116,15 @@ describe ValidatesCpfCnpj do
         end
       end
       
-
+      all_equal_chars_cnpjs = %w{11111111111111 22222222222222 33333333333333 44444444444444 55555555555555 66666666666666 77777777777777 88888888888888 99999999999999 00000000000000}
+      all_equal_chars_cnpjs.each do |cnpj|
+        it "value is #{cnpj}" do
+          person = Person.new(:code => cnpj)
+          person.validates_cnpj(:code)
+          person.errors.should_not be_empty
+        end
+      end
+      
       it 'value is nil' do
         person = Person.new(:code => nil)
         person.validates_cnpj(:code)

--- a/spec/lib/validates_cpf_cnpj_spec.rb
+++ b/spec/lib/validates_cpf_cnpj_spec.rb
@@ -50,7 +50,7 @@ describe ValidatesCpfCnpj do
       it 'value is a cnpj' do
         person = Person.new(:code => '05.393.625/0001-84')
         person.validates_cpf(:code)
-        person.errors.should_not be_empty
+        expect(person.errors).not_to be_empty
       end
     end
 
@@ -154,10 +154,16 @@ describe ValidatesCpfCnpj do
         expect(person.errors).not_to be_empty
       end
 
+      it 'value is incompletelly formatted' do
+        person = Person.new(:code => '00105063/000102')
+        person.validates_cnpj(:code)
+        expect(person.errors).not_to be_empty
+      end
+
       it 'value is a cpf' do
         person = Person.new(:code => '800.337.878-83')
         person.validates_cnpj(:code)
-        person.errors.should_not be_empty
+        expect(person.errors).not_to be_empty
       end
     end
 
@@ -221,8 +227,8 @@ describe ValidatesCpfCnpj do
     it 'should add custom message to the error messages when it is present' do
       person = Person.new(:code => '123')
       person.validates_cnpj(:code, :message => 'doesnt fit our CNPJ standards')
-      person.errors.should_not be_empty
-      person.errors.messages[:code].should include 'doesnt fit our CNPJ standards'
+      expect(person.errors).not_to be_empty
+      expect(person.errors.messages[:code]).to include 'doesnt fit our CNPJ standards'
     end
   end
 

--- a/spec/lib/validates_cpf_cnpj_spec.rb
+++ b/spec/lib/validates_cpf_cnpj_spec.rb
@@ -40,6 +40,12 @@ describe ValidatesCpfCnpj do
           person.errors.should_not be_empty
         end
       end
+
+      it 'value is a cnpj' do
+        person = Person.new(:code => '05.393.625/0001-84')
+        person.validates_cpf(:code)
+        person.errors.should_not be_empty
+      end
     end
 
     context 'should be valid when' do
@@ -125,6 +131,12 @@ describe ValidatesCpfCnpj do
 
       it 'value is empty' do
         person = Person.new(:code => '')
+        person.validates_cnpj(:code)
+        person.errors.should_not be_empty
+      end
+
+      it 'value is a cpf' do
+        person = Person.new(:code => '800.337.878-83')
         person.validates_cnpj(:code)
         person.errors.should_not be_empty
       end

--- a/spec/lib/validates_cpf_cnpj_spec.rb
+++ b/spec/lib/validates_cpf_cnpj_spec.rb
@@ -9,7 +9,7 @@ describe ValidatesCpfCnpj do
 
     context 'should be invalid when' do
       invalid_cpfs = %w{1234567890 12345678901 ABC45678901 123.456.789-01 800337.878-83 800337878-83}
-      
+
       invalid_cpfs.each do |cpf|
         it "value is #{cpf}" do
           person = Person.new(:code => cpf)
@@ -85,7 +85,7 @@ describe ValidatesCpfCnpj do
 
       it ':on option is :create and the model instance is not a new record' do
         person = Person.new(:code => '12345678901')
-        person.stub!(:new_record?, false)
+        allow(person).to receive(:new_record?).and_return(false)
         person.validates_cpf(:code, :on => :create)
         person.errors.should be_empty
       end
@@ -115,7 +115,7 @@ describe ValidatesCpfCnpj do
           person.errors.should_not be_empty
         end
       end
-      
+
       all_equal_chars_cnpjs = %w{11111111111111 22222222222222 33333333333333 44444444444444 55555555555555 66666666666666 77777777777777 88888888888888 99999999999999 00000000000000}
       all_equal_chars_cnpjs.each do |cnpj|
         it "value is #{cnpj}" do
@@ -124,7 +124,7 @@ describe ValidatesCpfCnpj do
           person.errors.should_not be_empty
         end
       end
-      
+
       it 'value is nil' do
         person = Person.new(:code => nil)
         person.validates_cnpj(:code)
@@ -181,7 +181,7 @@ describe ValidatesCpfCnpj do
 
       it ':on option is :create and the model instance is not a new record' do
         person = Person.new(:code => '12345678901')
-        person.stub!(:new_record?, false)
+        allow(person).to receive(:new_record?).and_return(false)
         person.validates_cnpj(:code, :on => :create)
         person.errors.should be_empty
       end
@@ -191,6 +191,15 @@ describe ValidatesCpfCnpj do
         person.validates_cnpj(:code, :on => :update)
         person.errors.should be_empty
       end
+    end
+  end
+
+  describe 'custom messages' do
+    it 'should add custom message to the error messages when it is present' do
+      person = Person.new(:code => '123')
+      person.validates_cnpj(:code, :message => 'doesnt fit our CNPJ standards')
+      person.errors.should_not be_empty
+      person.errors.messages[:code].should include 'doesnt fit our CNPJ standards'
     end
   end
 
@@ -267,7 +276,7 @@ describe ValidatesCpfCnpj do
 
       it ':on option is :create and the model instance is not a new record' do
         person = Person.new(:code => '12345678901')
-        person.stub!(:new_record?, false)
+        allow(person).to receive(:new_record?).and_return(false)
         person.validates_cpf_or_cnpj(:code, :on => :create)
         person.errors.should be_empty
       end
@@ -320,7 +329,7 @@ describe ValidatesCpfCnpj do
 
       it ':on option is :create and the model instance is not a new record' do
         person = Person.new(:code => '12345678901')
-        person.stub!(:new_record?, false)
+        allow(person).to receive(:new_record?).and_return(false)
         person.validates_cpf_or_cnpj(:code, :on => :create)
         person.errors.should be_empty
       end

--- a/spec/lib/validates_cpf_cnpj_spec.rb
+++ b/spec/lib/validates_cpf_cnpj_spec.rb
@@ -4,30 +4,30 @@ describe ValidatesCpfCnpj do
   describe 'validates_cpf' do
     it 'should raise an ArgumentError when no attribute is informed' do
       person = Person.new
-      lambda { person.validates_cpf }.should raise_exception(ArgumentError, 'You need to supply at least one attribute')
+      expect { person.validates_cpf }.to raise_exception(ArgumentError, 'You need to supply at least one attribute')
     end
 
     context 'should be invalid when' do
       invalid_cpfs = %w{1234567890 12345678901 ABC45678901 123.456.789-01 800337.878-83 800337878-83}
-      
+
       invalid_cpfs.each do |cpf|
         it "value is #{cpf}" do
           person = Person.new(:code => cpf)
           person.validates_cpf(:code)
-          person.errors.should_not be_empty
+          expect(person.errors).not_to be_empty
         end
       end
 
       it 'value is nil' do
         person = Person.new(:code => nil)
         person.validates_cpf(:code)
-        person.errors.should_not be_empty
+        expect(person.errors).not_to be_empty
       end
 
       it 'value is empty' do
         person = Person.new(:code => '')
         person.validates_cpf(:code)
-        person.errors.should_not be_empty
+        expect(person.errors).not_to be_empty
       end
 
       # This numbers will be considered valid by the algorithm but is known as not valid on real world, so they should be blocked
@@ -37,7 +37,7 @@ describe ValidatesCpfCnpj do
         it "is a well know invalid number: #{cpf}" do
           person = Person.new(:code => cpf)
           person.validates_cpf(:code)
-          person.errors.should_not be_empty
+          expect(person.errors).not_to be_empty
         end
       end
     end
@@ -46,54 +46,54 @@ describe ValidatesCpfCnpj do
       it 'value is 80033787883' do
         person = Person.new(:code => '80033787883')
         person.validates_cpf(:code)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it 'value is 800.337.878-83' do
         person = Person.new(:code => '800.337.878-83')
         person.validates_cpf(:code)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it 'value is nil and :allow_nil or :allow_blank is true' do
         person = Person.new(:code => nil)
         person.validates_cpf(:code, :allow_nil => true)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
         person.validates_cpf(:code, :allow_blank => true)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it 'value is empty and :allow_blank is true' do
         person = Person.new(:code => '')
         person.validates_cpf(:code, :allow_blank => true)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
         person.validates_cpf(:code, :allow_nil => true)
-        person.errors.should_not be_empty
+        expect(person.errors).to_not be_empty
       end
 
       it ':if option evaluates false' do
         person = Person.new(:code => '12345678901')
         person.validates_cpf(:code, :if => false)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it ':unless option evaluates true' do
         person = Person.new(:code => '12345678901')
         person.validates_cpf(:code, :unless => true)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it ':on option is :create and the model instance is not a new record' do
         person = Person.new(:code => '12345678901')
-        person.stub!(:new_record?, false)
+        allow(person).to receive(:new_record?).and_return(false)
         person.validates_cpf(:code, :on => :create)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it ':on option is :update and the model instance is a new record' do
         person = Person.new(:code => '12345678901')
         person.validates_cpf(:code, :on => :update)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
     end
   end
@@ -101,7 +101,7 @@ describe ValidatesCpfCnpj do
   describe 'validates_cnpj' do
     it 'should raise an ArgumentError when no attribute is informed' do
       person = Person.new
-      lambda { person.validates_cnpj }.should raise_exception(ArgumentError, 'You need to supply at least one attribute')
+      expect { person.validates_cnpj }.to raise_exception(ArgumentError, 'You need to supply at least one attribute')
     end
 
     context 'should be invalid when' do
@@ -112,21 +112,21 @@ describe ValidatesCpfCnpj do
         it "value is #{cnpj}" do
           person = Person.new(:code => cnpj)
           person.validates_cnpj(:code)
-          person.errors.should_not be_empty
+          expect(person.errors).to_not be_empty
         end
       end
-      
+
 
       it 'value is nil' do
         person = Person.new(:code => nil)
         person.validates_cnpj(:code)
-        person.errors.should_not be_empty
+        expect(person.errors).to_not be_empty
       end
 
       it 'value is empty' do
         person = Person.new(:code => '')
         person.validates_cnpj(:code)
-        person.errors.should_not be_empty
+        expect(person.errors).to_not be_empty
       end
     end
 
@@ -134,54 +134,54 @@ describe ValidatesCpfCnpj do
       it 'value is 05393625000184' do
         person = Person.new(:code => '05393625000184')
         person.validates_cnpj(:code)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it 'value is 05.393.625/0001-84' do
         person = Person.new(:code => '05.393.625/0001-84')
         person.validates_cnpj(:code)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it 'value is nil and :allow_nil or :allow_blank is true' do
         person = Person.new(:code => nil)
         person.validates_cnpj(:code, :allow_nil => true)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
         person.validates_cnpj(:code, :allow_blank => true)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it 'value is empty and :allow_blank is true' do
         person = Person.new(:code => '')
         person.validates_cnpj(:code, :allow_blank => true)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
         person.validates_cnpj(:code, :allow_nil => true)
-        person.errors.should_not be_empty
+        expect(person.errors).to_not be_empty
       end
 
       it ':if option evaluates false' do
         person = Person.new(:code => '12345678901234')
         person.validates_cnpj(:code, :if => false)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it ':unless option evaluates true' do
         person = Person.new(:code => '12345678901234')
         person.validates_cnpj(:code, :unless => true)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it ':on option is :create and the model instance is not a new record' do
         person = Person.new(:code => '12345678901')
-        person.stub!(:new_record?, false)
+        allow(person).to receive(:new_record?).and_return(false)
         person.validates_cnpj(:code, :on => :create)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it ':on option is :update and the model instance is a new record' do
         person = Person.new(:code => '12345678901')
         person.validates_cnpj(:code, :on => :update)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
     end
   end
@@ -189,7 +189,7 @@ describe ValidatesCpfCnpj do
   describe 'validates_cpf_or_cnpj' do
     it 'should raise an ArgumentError when no attribute is informed' do
       person = Person.new
-      lambda { person.validates_cpf_or_cnpj }.should raise_exception(ArgumentError, 'You need to supply at least one attribute')
+      expect { person.validates_cpf_or_cnpj }.to raise_exception(ArgumentError, 'You need to supply at least one attribute')
     end
 
     context 'should be invalid when' do
@@ -199,20 +199,20 @@ describe ValidatesCpfCnpj do
         it "value is #{number}" do
           person = Person.new(:code => number)
           person.validates_cpf_or_cnpj(:code)
-          person.errors.should_not be_empty
+          expect(person.errors).to_not be_empty
         end
       end
 
       it 'value is nil' do
         person = Person.new(:code => nil)
         person.validates_cpf_or_cnpj(:code)
-        person.errors.should_not be_empty
+        expect(person.errors).to_not be_empty
       end
 
       it 'value is empty' do
         person = Person.new(:code => '')
         person.validates_cpf_or_cnpj(:code)
-        person.errors.should_not be_empty
+        expect(person.errors).to_not be_empty
       end
     end
 
@@ -220,107 +220,107 @@ describe ValidatesCpfCnpj do
       it 'value is 80033787883' do
         person = Person.new(:code => '80033787883')
         person.validates_cpf_or_cnpj(:code)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it 'value is 800.337.878-83' do
         person = Person.new(:code => '800.337.878-83')
         person.validates_cpf_or_cnpj(:code)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it 'value is nil and :allow_nil or :allow_blank is true' do
         person = Person.new(:code => nil)
         person.validates_cpf_or_cnpj(:code, :allow_nil => true)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
         person.validates_cpf_or_cnpj(:code, :allow_blank => true)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it 'value is empty and :allow_blank is true' do
         person = Person.new(:code => '')
         person.validates_cpf_or_cnpj(:code, :allow_blank => true)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
         person.validates_cpf_or_cnpj(:code, :allow_nil => true)
-        person.errors.should_not be_empty
+        expect(person.errors).to_not be_empty
       end
 
       it ':if option evaluates false' do
         person = Person.new(:code => '12345678901')
         person.validates_cpf_or_cnpj(:code, :if => false)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it ':unless option evaluates true' do
         person = Person.new(:code => '12345678901')
         person.validates_cpf_or_cnpj(:code, :unless => true)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it ':on option is :create and the model instance is not a new record' do
         person = Person.new(:code => '12345678901')
-        person.stub!(:new_record?, false)
+        allow(person).to receive(:new_record?).and_return(false)
         person.validates_cpf_or_cnpj(:code, :on => :create)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it ':on option is :update and the model instance is a new record' do
         person = Person.new(:code => '12345678901')
         person.validates_cpf_or_cnpj(:code, :on => :update)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it 'value is 05393625000184' do
         person = Person.new(:code => '05393625000184')
         person.validates_cpf_or_cnpj(:code)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it 'value is 05.393.625/0001-84' do
         person = Person.new(:code => '05.393.625/0001-84')
         person.validates_cpf_or_cnpj(:code)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it 'value is nil and :allow_nil or :allow_blank is true' do
         person = Person.new(:code => nil)
         person.validates_cpf_or_cnpj(:code, :allow_nil => true)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
         person.validates_cpf_or_cnpj(:code, :allow_blank => true)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it 'value is empty and :allow_blank is true' do
         person = Person.new(:code => '')
         person.validates_cpf_or_cnpj(:code, :allow_blank => true)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
         person.validates_cpf_or_cnpj(:code, :allow_nil => true)
-        person.errors.should_not be_empty
+        expect(person.errors).to_not be_empty
       end
 
       it ':if option evaluates false' do
         person = Person.new(:code => '12345678901234')
         person.validates_cpf_or_cnpj(:code, :if => false)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it ':unless option evaluates true' do
         person = Person.new(:code => '12345678901234')
         person.validates_cpf_or_cnpj(:code, :unless => true)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it ':on option is :create and the model instance is not a new record' do
         person = Person.new(:code => '12345678901')
-        person.stub!(:new_record?, false)
+        allow(person).to receive(:new_record?).and_return(false)
         person.validates_cpf_or_cnpj(:code, :on => :create)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
 
       it ':on option is :update and the model instance is a new record' do
         person = Person.new(:code => '12345678901')
         person.validates_cpf_or_cnpj(:code, :on => :update)
-        person.errors.should be_empty
+        expect(person.errors).to be_empty
       end
     end
   end

--- a/spec/lib/validates_cpf_cnpj_spec.rb
+++ b/spec/lib/validates_cpf_cnpj_spec.rb
@@ -7,6 +7,12 @@ describe ValidatesCpfCnpj do
       expect { person.validates_cpf }.to raise_exception(ArgumentError, 'You need to supply at least one attribute')
     end
 
+    it 'should return a formatted CPF if the value is valid' do
+      person = Person.new(:code => '80033787883')
+      person.validates_cpf(:code)
+      expect(person.code).to eq '800.337.878-83'
+    end
+
     context 'should be invalid when' do
       invalid_cpfs = %w{1234567890 12345678901 ABC45678901 123.456.789-01 800337.878-83 800337878-83}
 
@@ -110,8 +116,13 @@ describe ValidatesCpfCnpj do
       expect { person.validates_cnpj }.to raise_exception(ArgumentError, 'You need to supply at least one attribute')
     end
 
-    context 'should be invalid when' do
+    it 'should return a formatted CNPJ if the value is valid' do
+      person = Person.new(:code => '05393625000184')
+      person.validates_cnpj(:code)
+      expect(person.code).to eq '05.393.625/0001-84'
+    end
 
+    context 'should be invalid when' do
       invalid_cnpjs = %w{1234567890123 12345678901234 123456789012345 ABC05393625000184 12.345.678/9012-34 05393.625/0001-84 05393.6250001-84 00.000.000/0000-00}
 
       invalid_cnpjs.each do |cnpj|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,8 @@
 require 'validates_cpf_cnpj'
 require 'active_record'
 
+I18n.enforce_available_locales = false
+
 ActiveRecord::Base.establish_connection(
   :adapter => 'sqlite3',
   :database => ':memory:'

--- a/validates_cpf_cnpj.gemspec
+++ b/validates_cpf_cnpj.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"
   s.add_development_dependency "activerecord"
+  s.add_development_dependency "sqlite3"
 
   s.add_runtime_dependency "activemodel", ">= 3.0.0"
 end


### PR DESCRIPTION
The CPNJ 00.000.000/0000-00 was been considered valid. Now the CNPJ fields are invalid when there are 14 or more repeated chars: (00...0, 11...1, ..., 99..9).
