### PR TITLE
Preventing error for trying to modify a frozen string.

### DIFF
--- a/lib/validates_cpf_cnpj/cpf.rb
+++ b/lib/validates_cpf_cnpj/cpf.rb
@@ -2,8 +2,8 @@ module ValidatesCpfCnpj
   module Cpf
     @@invalid_cpfs = %w{12345678909 11111111111 22222222222 33333333333 44444444444 55555555555 66666666666 77777777777 88888888888 99999999999 00000000000}
 
-    def self.valid?(value)
-      value.gsub!(/[^0-9]/, '')
+    def self.valid?(v)
+      value = v.gsub(/[^0-9]/, '')
 
       return false if @@invalid_cpfs.member?(value)
       


### PR DESCRIPTION
This line were triggering an error for trying to modify a frozen string. Since it's nor necessary to change the string object itself, we can just store the value in another variable.